### PR TITLE
Prevent unnecessary refresh

### DIFF
--- a/app/src/main/java/com/isscroberto/dailyprayerandroid/prayer/PrayerActivity.java
+++ b/app/src/main/java/com/isscroberto/dailyprayerandroid/prayer/PrayerActivity.java
@@ -118,6 +118,10 @@ public class PrayerActivity extends DaggerAppCompatActivity implements PrayerCon
                 }
             });
         }
+
+        // Load prayer.
+        mPresenter.takeView(this);
+        mPresenter.reload();
     }
 
     @Override
@@ -175,17 +179,19 @@ public class PrayerActivity extends DaggerAppCompatActivity implements PrayerCon
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-        if (requestCode == 1) {
-            // Verify if ads are enabled.
-            boolean adsEnabled = getSharedPreferences("com.isscroberto.dailyprayerandroid", MODE_PRIVATE).getBoolean("AdsEnabled", true);
-            if (!adsEnabled) {
-                adView.setVisibility(View.GONE);
-            }
+        switch (requestCode) {
+            case 1:
+                // Verify if ads are enabled.
+                boolean adsEnabled = getSharedPreferences("com.isscroberto.dailyprayerandroid", MODE_PRIVATE).getBoolean("AdsEnabled", true);
+                if (!adsEnabled) {
+                    adView.setVisibility(View.GONE);
+                }
+                break;
+            case 2:
+                // Verify if prayer is favorited.
+                mPresenter.reload();
+                break;
         }
-        //if (requestCode == 2) {
-            // Verify if prayer is favorited.
-            //mPresenter.start();
-        //}
     }
 
     @Override
@@ -198,7 +204,7 @@ public class PrayerActivity extends DaggerAppCompatActivity implements PrayerCon
         mPrayer.setDescription(Html.fromHtml(mPrayer.getDescription()).toString());
         textTitle.setText(mPrayer.getTitle());
         textContent.setText(mPrayer.getDescription());
-        if(mPrayer.getFav()) {
+        if (mPrayer.getFav()) {
             buttonFav.setImageDrawable(ContextCompat.getDrawable(this, R.drawable.ic_favorite_24dp));
         } else {
             buttonFav.setImageDrawable(ContextCompat.getDrawable(this, R.drawable.ic_favorite_border_24dp));
@@ -233,7 +239,7 @@ public class PrayerActivity extends DaggerAppCompatActivity implements PrayerCon
 
     @Override
     public void onRefresh() {
-        mPresenter.takeView(this);
+        mPresenter.reload();
     }
 
     @OnClick(R.id.button_fav)
@@ -244,7 +250,7 @@ public class PrayerActivity extends DaggerAppCompatActivity implements PrayerCon
             df.setTimeZone(TimeZone.getTimeZone("gmt"));
             String id = df.format(new Date());
 
-            if(!mPrayer.getFav()) {
+            if (!mPrayer.getFav()) {
                 // Prepare prayer for storage.
                 Prayer newPrayer = new Prayer();
                 newPrayer.setId(id);
@@ -276,9 +282,9 @@ public class PrayerActivity extends DaggerAppCompatActivity implements PrayerCon
         startActivityForResult(intent, 2);
     }
 
-    private void redrawFab(){
+    private void redrawFab() {
         buttonFav.hide();
-        if(mPrayer.getFav()) {
+        if (mPrayer.getFav()) {
             buttonFav.setImageDrawable(ContextCompat.getDrawable(this, R.drawable.ic_favorite_24dp));
         } else {
             buttonFav.setImageDrawable(ContextCompat.getDrawable(this, R.drawable.ic_favorite_border_24dp));

--- a/app/src/main/java/com/isscroberto/dailyprayerandroid/prayer/PrayerContract.java
+++ b/app/src/main/java/com/isscroberto/dailyprayerandroid/prayer/PrayerContract.java
@@ -19,6 +19,7 @@ public interface PrayerContract {
     }
 
     interface Presenter extends BasePresenter<View> {
+        void reload();
         void loadPrayer();
         void loadImage();
         void savePrayer(Prayer prayer);

--- a/app/src/main/java/com/isscroberto/dailyprayerandroid/prayer/PrayerPresenter.java
+++ b/app/src/main/java/com/isscroberto/dailyprayerandroid/prayer/PrayerPresenter.java
@@ -43,6 +43,12 @@ public class PrayerPresenter implements PrayerContract.Presenter {
     }
 
     @Override
+    public void reload() {
+        loadPrayer();
+        loadImage();
+    }
+
+    @Override
     public void loadPrayer() {
         mView.setLoadingIndicator(true);
         mPrayerDataSource.get(new Callback<RssResponse>() {
@@ -116,8 +122,6 @@ public class PrayerPresenter implements PrayerContract.Presenter {
     @Override
     public void takeView(PrayerContract.View prayerView) {
         this.mView = prayerView;
-        loadPrayer();
-        loadImage();
     }
 
     @Override

--- a/app/src/test/java/com/isscroberto/dailyprayerandroid/PrayerPresenterTest.java
+++ b/app/src/test/java/com/isscroberto/dailyprayerandroid/PrayerPresenterTest.java
@@ -78,7 +78,8 @@ public class PrayerPresenterTest {
     public void loadPrayerAndLoadIntoView() {
         Call<RssResponse> mockedCall = Mockito.mock(Call.class);
 
-        // When presenter starts load prayer is called on takeView.
+        // When activity starts it request to reload prayer and image.
+        mPrayerPresenter.reload();
 
         // Then progress indicator is shown and prayer is requested from the remote repository.
         verify(mPrayerView).setLoadingIndicator(true);
@@ -97,7 +98,8 @@ public class PrayerPresenterTest {
     public void loadImageAndLoadIntoView() {
         Call mockedCall = Mockito.mock(Call.class);
 
-        // When presenter starts load image is called on takeView.
+        // When activity starts it request to reload prayer and image.
+        mPrayerPresenter.reload();
 
         // Capture callback and invoke with mock image.
         verify(mImageRemoteDataSource).get(mBingResponseCallbackCaptor.capture());


### PR DESCRIPTION
Fixes #17 by changing prayer reload process to prevent unnecessary refresh every time the view gets focused.
- Load prayer on activity created.
- Reload prayer when coming back from favorites.
- Reload prayer on user swipe to refresh.