### PR TITLE
Enable Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,3 +31,5 @@ before_install:
   - chmod +x gradlew
 script:
     - ./gradlew build check jacocoTestReport
+after_success:
+    - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Fixes #11 by adding instruction to upload coverage reports on Travis configuration.